### PR TITLE
Update Home Assistant Extension Version

### DIFF
--- a/extensions/PrimusNZ.json
+++ b/extensions/PrimusNZ.json
@@ -5,7 +5,7 @@
             "details": {
                 "author": "PrimusNZ",
                 "description": "Allows SAMMI to interface with Home Assistant to turn switches and lights on or off, or trigger scenes and scripts",
-                "latest_version": "0.3",
+                "latest_version": "0.4",
                 "download_link": "https://github.com/PrimusNZ/SAMMI-HomeAssistant"
             }
         }


### PR DESCRIPTION
Home Assistant Extension Ver 0.4 now allows pulling any entity state from Home Assistant into SAMMI.